### PR TITLE
Push docker deployment to docker repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /app
 COPY gradlew .
 COPY gradle gradle
 COPY build.gradle.kts .
-COPY settings.gradle.kts .
 
 # Make gradlew executable
 RUN chmod +x gradlew
@@ -23,7 +22,7 @@ COPY src src
 RUN ./gradlew build -x test --no-daemon
 
 # Production stage
-FROM openjdk:17-jre-slim
+FROM eclipse-temurin:17-jre
 
 # Create app user for security
 RUN groupadd -r appuser && useradd -r -g appuser appuser
@@ -32,7 +31,7 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 WORKDIR /app
 
 # Copy the built jar from build stage
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY --from=build /app/build/libs/*-1.0.0.jar app.jar
 
 # Change ownership to app user
 RUN chown appuser:appuser app.jar


### PR DESCRIPTION
Fix Dockerfile to enable successful image build for deployment.

The original Dockerfile failed to build due to a non-existent `settings.gradle.kts` file, an unavailable base image (`openjdk:17-jre-slim`), and incorrect JAR file copying logic. These changes resolve those issues, allowing the Spring Boot application to be correctly packaged into a Docker image.

---
<a href="https://cursor.com/background-agent?bcId=bc-64423f2d-abbe-4c63-8a50-ff49616a6ad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64423f2d-abbe-4c63-8a50-ff49616a6ad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>